### PR TITLE
Add unlimited option to traffic generator.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,3 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
-
-# IDE
-.idea/
-

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+# IDE
+.idea/
+

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/blend/go-sdk v1.0.0 // indirect
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/guptarohit/asciigraph v0.4.1
+	github.com/kr/pretty v0.1.0 // indirect
 	github.com/wcharczuk/go-chart v2.0.1+incompatible
 	golang.org/x/image v0.0.0-20181116024801-cd38e8056d9b // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ github.com/blend/go-jmespath v0.0.0-20181007162024-55fce72ef207/go.mod h1:Hu7ril
 github.com/blend/go-sdk v0.3.5/go.mod h1:1kUAbD7Saj6vObzdGw8rmHLse2OYM7hkHX4GwA7dbr4=
 github.com/blend/go-sdk v1.0.0-b001 h1:Sbzn+1JcTM7GnNEIoLdS/ICqPJi99PVzkda2luLrpI4=
 github.com/blend/go-sdk v1.0.0-b001/go.mod h1:3GUb0YsHFNTJ6hsJTpzdmCUl05o8HisKjx5OAlzYKdw=
+github.com/blend/go-sdk v1.0.0 h1:GBBqzN85Ftdl+XLK6C8YEd/seSY1/cEqf05di/n8KoY=
 github.com/blend/go-sdk v1.0.0/go.mod h1:3GUb0YsHFNTJ6hsJTpzdmCUl05o8HisKjx5OAlzYKdw=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
@@ -12,6 +13,11 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/guptarohit/asciigraph v0.4.1 h1:YHmCMN8VH81BIUIgTg2Fs3B52QDxNZw2RQ6j5pGoSxo=
 github.com/guptarohit/asciigraph v0.4.1/go.mod h1:9fYEfE5IGJGxlP1B+w8wHFy7sNZMhPtn59f0RLtpRFM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.2/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -27,6 +33,7 @@ golang.org/x/image v0.0.0-20181116024801-cd38e8056d9b h1:VHyIDlv3XkfCa5/a81uzaoD
 golang.org/x/image v0.0.0-20181116024801-cd38e8056d9b/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/goben/client.go
+++ b/goben/client.go
@@ -139,7 +139,7 @@ func handleConnectionClient(app *config, wg *sync.WaitGroup, conn net.Conn, c, c
 	var input *ChartData
 	var output *ChartData
 
-	if app.csv != "" || app.export != "" || app.chart != "" || app.ascii {
+	if !app.disableChart && (app.csv != "" || app.export != "" || app.chart != "" || app.ascii) {
 		input = &info.Input
 		output = &info.Output
 	}

--- a/goben/client.go
+++ b/goben/client.go
@@ -139,7 +139,7 @@ func handleConnectionClient(app *config, wg *sync.WaitGroup, conn net.Conn, c, c
 	var input *ChartData
 	var output *ChartData
 
-	if !app.disableChart && (app.csv != "" || app.export != "" || app.chart != "" || app.ascii) {
+	if app.csv != "" || app.export != "" || app.chart != "" || app.ascii {
 		input = &info.Input
 		output = &info.Output
 	}

--- a/goben/main.go
+++ b/goben/main.go
@@ -27,7 +27,6 @@ type config struct {
 	opt            options
 	passiveClient  bool // suppress client send
 	udp            bool
-	disableChart   bool // disable chart rendering
 	chart          string
 	export         string
 	csv            string
@@ -70,18 +69,17 @@ func main() {
 	flag.StringVar(&app.defaultPort, "defaultPort", ":8080", "default port")
 	flag.IntVar(&app.connections, "connections", 1, "number of parallel connections")
 	flag.StringVar(&app.reportInterval, "reportInterval", "2s", "periodic report interval\nunspecified time unit defaults to second")
-	flag.StringVar(&app.totalDuration, "totalDuration", "10s", "test total duration\nunspecified time unit defaults to second\ninf means unlimited time, and when it's set to inf, disableChart is set to true")
+	flag.StringVar(&app.totalDuration, "totalDuration", "10s", "test total duration\nunspecified time unit defaults to second\ninf means unlimited time, and when it's set to inf, no ascii chart will be rendered")
 	flag.IntVar(&app.opt.ReadSize, "readSize", 50000, "read buffer size in bytes")
 	flag.IntVar(&app.opt.WriteSize, "writeSize", 50000, "write buffer size in bytes")
 	flag.BoolVar(&app.passiveClient, "passiveClient", false, "suppress client writes")
 	flag.BoolVar(&app.opt.PassiveServer, "passiveServer", false, "suppress server writes")
 	flag.Float64Var(&app.opt.MaxSpeed, "maxSpeed", 0, "bandwidth limit in mbps (0 means unlimited)")
 	flag.BoolVar(&app.udp, "udp", false, "run client in UDP mode")
-	flag.BoolVar(&app.disableChart, "disableChart", false, "disable chart rendering\nwhen totalDuration is inf, this will always be set to true")
 	flag.StringVar(&app.chart, "chart", "", "output filename for rendering chart on client\n'%d' is parallel connection index to host\n'%s' is hostname:port\nexample: -chart chart-%d-%s.png")
 	flag.StringVar(&app.export, "export", "", "output filename for YAML exporting test results on client\n'%d' is parallel connection index to host\n'%s' is hostname:port\nexample: -export export-%d-%s.yaml")
 	flag.StringVar(&app.csv, "csv", "", "output filename for CSV exporting test results on client\n'%d' is parallel connection index to host\n'%s' is hostname:port\nexample: -csv export-%d-%s.csv")
-	flag.BoolVar(&app.ascii, "ascii", true, "plot ascii chart")
+	flag.BoolVar(&app.ascii, "ascii", true, "plot ascii chart\nthis will automatically set to false when totalDuration is inf")
 	flag.BoolVar(&app.silent, "silent", false, "Do not print any output")
 	flag.StringVar(&app.tlsKey, "key", "key.pem", "TLS key file")
 	flag.StringVar(&app.tlsCert, "cert", "cert.pem", "TLS cert file")
@@ -105,10 +103,10 @@ func main() {
 	}
 
 	app.reportInterval = defaultTimeUnit(app.reportInterval)
-	
+
 	// when the user want to generate the traffic for unlimited time, disable chart rendering to avoid memory overflow
 	if app.totalDuration == "inf" {
-		app.disableChart = true
+		app.ascii = false
 	}
 	app.totalDuration = defaultTimeUnit(app.totalDuration)
 

--- a/goben/main.go
+++ b/goben/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"math"
 	"runtime"
 	"strconv"
 	"strings"
@@ -68,7 +69,7 @@ func main() {
 	flag.StringVar(&app.defaultPort, "defaultPort", ":8080", "default port")
 	flag.IntVar(&app.connections, "connections", 1, "number of parallel connections")
 	flag.StringVar(&app.reportInterval, "reportInterval", "2s", "periodic report interval\nunspecified time unit defaults to second")
-	flag.StringVar(&app.totalDuration, "totalDuration", "10s", "test total duration\nunspecified time unit defaults to second")
+	flag.StringVar(&app.totalDuration, "totalDuration", "10s", "test total duration\nunspecified time unit defaults to second\ninf means unlimited time")
 	flag.IntVar(&app.opt.ReadSize, "readSize", 50000, "read buffer size in bytes")
 	flag.IntVar(&app.opt.WriteSize, "writeSize", 50000, "write buffer size in bytes")
 	flag.BoolVar(&app.passiveClient, "passiveClient", false, "suppress client writes")
@@ -146,6 +147,11 @@ func main() {
 func defaultTimeUnit(s string) string {
 	if len(s) < 1 {
 		return s
+	}
+	// enable the client and server to generate traffic for an unlimited time duration
+	if s == "inf" {
+		// the longest possible time duration is 290 years, which is effectively infinite long
+		return strconv.FormatInt(math.MaxInt64, 10) + "ns"
 	}
 	if unicode.IsDigit(rune(s[len(s)-1])) {
 		return s + "s"

--- a/goben/main.go
+++ b/goben/main.go
@@ -105,11 +105,12 @@ func main() {
 	}
 
 	app.reportInterval = defaultTimeUnit(app.reportInterval)
-	app.totalDuration = defaultTimeUnit(app.totalDuration)
+	
 	// when the user want to generate the traffic for unlimited time, disable chart rendering to avoid memory overflow
 	if app.totalDuration == "inf" {
 		app.disableChart = true
 	}
+	app.totalDuration = defaultTimeUnit(app.totalDuration)
 
 	var errInterval error
 	app.opt.ReportInterval, errInterval = time.ParseDuration(app.reportInterval)

--- a/goben/main.go
+++ b/goben/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"math"
 	"runtime"
@@ -10,7 +11,6 @@ import (
 	"strings"
 	"time"
 	"unicode"
-	"io/ioutil"
 )
 
 const version = "0.4"


### PR DESCRIPTION
This pull request is to add an option to allow the server and clients to send traffic for an unlimited time. Goben already has a flag variable "totalDuration", the easiest way is to add a new option "inf" so that totalDuration=inf indicates running forever.

This change will have a side effect:
Previously, when the specified time duration expires, goben will read the collected stats from memory and render a chart.
But after the change, when we specify the time duration to be "inf", it will never expire and the traffic never stops unless we force quit the program (Ctrl + c). When this happens, no chart will be rendered and all the collected stats in the memory are gone. In this case, since we won't render the chart and also there is a risk of overflow the heap if we keep collecting chart data, I added a new option to explicitly disable chart data collecting and thus disable chart rendering.

However, this side effect should not be a problem since in our Iroko project, those hosts running goben traffic generator is not responsible for rendering charts. Their only jobs are generating traffic and collect traffic stats and sending them back to the controller. As long as the host is able to send the data/stats to controller, we are good.