### PR TITLE
Measure the completion time to send a fixed amount of data

### DIFF
--- a/goben/client.go
+++ b/goben/client.go
@@ -65,7 +65,7 @@ func spawnClient(app *config, wg *sync.WaitGroup, conn net.Conn, c, connections 
 	wg.Add(1)
 	go handleConnectionClient(app, wg, conn, c, connections, isTLS)
 	// turn off rtt measurement when measuring fixed flow completion time
-	if app.totalFlow == 0 {
+	if app.opt.TotalFlow == 0 {
 		wg.Add(1)
 		go handleMeasurement(app, targetHost, wg, c)
 	}
@@ -146,17 +146,17 @@ func handleConnectionClient(app *config, wg *sync.WaitGroup, conn net.Conn, c, c
 	var input *ChartData
 	var output *ChartData
 
-	if (app.csv != "" && app.totalDuration != "inf" && app.totalFlow == 0) || app.export != "" || app.chart != "" || app.ascii {
+	if (app.csv != "" && app.totalDuration != "inf" && opt.TotalFlow == 0) || app.export != "" || app.chart != "" || app.ascii {
 		input = &info.Input
 		output = &info.Output
 	}
 
-	go clientReader(conn, c, connections, doneReader, opt, input, app.totalFlow)
+	go clientReader(conn, c, connections, doneReader, opt, input, opt.TotalFlow)
 	if !app.passiveClient {
-		go clientWriter(conn, c, connections, doneWriter, opt, output, app.totalFlow)
+		go clientWriter(conn, c, connections, doneWriter, opt, output, opt.TotalFlow)
 	}
 
-	if app.totalFlow == 0 {
+	if opt.TotalFlow == 0 {
 		startTicker(app.opt.TotalDuration)
 		// clean up client
 		conn.Close() // force reader/writer to quit

--- a/goben/client.go
+++ b/goben/client.go
@@ -62,9 +62,13 @@ func open(app *config) {
 }
 
 func spawnClient(app *config, wg *sync.WaitGroup, conn net.Conn, c, connections int, isTLS bool, targetHost string) {
-	wg.Add(2)
+	wg.Add(1)
 	go handleConnectionClient(app, wg, conn, c, connections, isTLS)
-	go handleMeasurement(app, targetHost, wg, c)
+	// turn off rtt measurement when measuring fixed flow completion time
+	if app.totalFlow == 0 {
+		wg.Add(1)
+		go handleMeasurement(app, targetHost, wg, c)
+	}
 }
 
 func tlsDial(proto, h string) (net.Conn, error) {
@@ -79,8 +83,9 @@ func tlsDial(proto, h string) (net.Conn, error) {
 
 // ExportInfo records data for export
 type ExportInfo struct {
-	Input  ChartData
-	Output ChartData
+	Input  			ChartData
+	Output 			ChartData
+	completionTime	time.Duration
 }
 
 func sendOptions(app *config, conn io.Writer) error {
@@ -130,8 +135,8 @@ func handleConnectionClient(app *config, wg *sync.WaitGroup, conn net.Conn, c, c
 		log.Printf("handleConnectionClient: %s ack received", protoLabel(isTLS))
 	}
 
-	doneReader := make(chan struct{})
-	doneWriter := make(chan struct{})
+	doneReader := make(chan time.Duration)
+	doneWriter := make(chan time.Duration)
 
 	info := ExportInfo{
 		Input:  ChartData{},
@@ -141,55 +146,37 @@ func handleConnectionClient(app *config, wg *sync.WaitGroup, conn net.Conn, c, c
 	var input *ChartData
 	var output *ChartData
 
-	if (app.csv != "" && app.totalDuration != "inf") || app.export != "" || app.chart != "" || app.ascii {
+	if (app.csv != "" && app.totalDuration != "inf" && app.totalFlow == 0) || app.export != "" || app.chart != "" || app.ascii {
 		input = &info.Input
 		output = &info.Output
 	}
 
-	go clientReader(conn, c, connections, doneReader, opt, input)
+	go clientReader(conn, c, connections, doneReader, opt, input, app.totalFlow)
 	if !app.passiveClient {
-		go clientWriter(conn, c, connections, doneWriter, opt, output)
+		go clientWriter(conn, c, connections, doneWriter, opt, output, app.totalFlow)
 	}
 
-	startTicker(app.opt.TotalDuration)
+	if app.totalFlow == 0 {
+		startTicker(app.opt.TotalDuration)
+		// clean up client
+		conn.Close() // force reader/writer to quit
 
-	conn.Close() // force reader/writer to quit
-
-	<-doneReader // wait reader exit
-	if !app.passiveClient {
-		<-doneWriter // wait writer exit
-	}
-
-	if app.csv != "" && app.totalDuration != "inf" {
-		filename := fmt.Sprintf(app.csv, c, conn.RemoteAddr())
-		log.Printf("exporting CSV test results to: %s", filename)
-		errExport := exportCsv(filename, &info)
-		if errExport != nil {
-			log.Printf("handleConnectionClient: export CSV: %s: %v", filename, errExport)
+		<-doneReader // wait reader exit
+		if !app.passiveClient {
+			<-doneWriter // wait writer exit
 		}
-	}
-
-	if app.export != "" {
-		filename := fmt.Sprintf(app.export, c, conn.RemoteAddr())
-		log.Printf("exporting YAML test results to: %s", filename)
-		errExport := export(filename, &info)
-		if errExport != nil {
-			log.Printf("handleConnectionClient: export YAML: %s: %v", filename, errExport)
+		generateDeliverables(app, c, conn, &info)
+		log.Printf("handleConnectionClient: closing: %d/%d %v", c, connections, conn.RemoteAddr())
+	} else {
+		<-doneReader // wait reader exit
+		if !app.passiveClient {
+			info.completionTime = <-doneWriter // wait writer exit
 		}
+
+		conn.Close()
+		generateDeliverables(app, c, conn, &info)
+		log.Printf("handleConnectionClient: closing: %d/%d %v", c, connections, conn.RemoteAddr())
 	}
-
-	if app.chart != "" {
-		filename := fmt.Sprintf(app.chart, c, conn.RemoteAddr())
-		log.Printf("rendering chart to: %s", filename)
-		errRender := chartRender(filename, &info.Input, &info.Output)
-		if errRender != nil {
-			log.Printf("handleConnectionClient: render PNG: %s: %v", filename, errRender)
-		}
-	}
-
-	plotascii(&info, conn.RemoteAddr().String(), c)
-
-	log.Printf("handleConnectionClient: closing: %d/%d %v", c, connections, conn.RemoteAddr())
 }
 
 // init and start Prober
@@ -227,28 +214,28 @@ func handleMeasurement(app *config, targetHost string, wg *sync.WaitGroup, connI
 		}
 }
 
-func clientReader(conn net.Conn, c, connections int, done chan struct{}, opt options, stat *ChartData) {
+func clientReader(conn net.Conn, c, connections int, done chan time.Duration, opt options, stat *ChartData, totalFlow uint64) {
 	log.Printf("clientReader: starting: %d/%d %v", c, connections, conn.RemoteAddr())
 
 	connIndex := fmt.Sprintf("%d/%d", c, connections)
 
 	buf := make([]byte, opt.ReadSize)
 
-	workLoop(connIndex, "clientReader", "rcv/s", conn.Read, buf, opt.ReportInterval, 0, stat)
+	workLoop(connIndex, "clientReader", "rcv/s", conn.Read, buf, opt.ReportInterval, 0, stat, done, totalFlow)
 
 	close(done)
 
 	log.Printf("clientReader: exiting: %d/%d %v", c, connections, conn.RemoteAddr())
 }
 
-func clientWriter(conn net.Conn, c, connections int, done chan struct{}, opt options, stat *ChartData) {
+func clientWriter(conn net.Conn, c, connections int, done chan time.Duration, opt options, stat *ChartData, totalFlow uint64) {
 	log.Printf("clientWriter: starting: %d/%d %v", c, connections, conn.RemoteAddr())
 
 	connIndex := fmt.Sprintf("%d/%d", c, connections)
 
 	buf := randBuf(opt.WriteSize)
 
-	workLoop(connIndex, "clientWriter", "snd/s", conn.Write, buf, opt.ReportInterval, opt.MaxSpeed, stat)
+	workLoop(connIndex, "clientWriter", "snd/s", conn.Write, buf, opt.ReportInterval, opt.MaxSpeed, stat, done, totalFlow)
 
 	close(done)
 
@@ -311,11 +298,12 @@ func (a *account) average(start time.Time, conn, label, cpsLabel string) {
 	log.Printf(fmtReport, conn, "average", label, mbps, cps, cpsLabel)
 }
 
-func workLoop(conn, label, cpsLabel string, f call, buf []byte, reportInterval time.Duration, maxSpeed float64, stat *ChartData) {
+func workLoop(conn, label, cpsLabel string, f call, buf []byte, reportInterval time.Duration, maxSpeed float64, stat *ChartData, done chan time.Duration, totalFlow uint64) {
 
 	start := time.Now()
 	acc := &account{}
 	acc.prevTime = start
+	totalBytesSoFar := 0
 
 	for {
 		runtime.Gosched()
@@ -331,7 +319,17 @@ func workLoop(conn, label, cpsLabel string, f call, buf []byte, reportInterval t
 			}
 		}
 
+		if totalFlow > 0 && uint64(totalBytesSoFar) >= totalFlow {
+			completionTime := time.Since(start)
+			if done != nil {
+				done <- completionTime // signal that the routine has completed
+			}
+			return
+		}
+
 		n, errCall := f(buf)
+		totalBytesSoFar = totalBytesSoFar + n
+
 		if errCall != nil {
 			log.Printf("workLoop: %s %s: %v", conn, label, errCall)
 			break
@@ -351,4 +349,35 @@ func startTicker(duration time.Duration) {
 	log.Printf("Connection lasts: %v timer", duration)
 
 	tickerPeriod.Stop()
+}
+
+func generateDeliverables(app *config, c int, conn net.Conn, info *ExportInfo) {
+	if app.csv != "" && app.totalDuration != "inf" {
+		filename := fmt.Sprintf(app.csv, c, conn.RemoteAddr())
+		log.Printf("exporting CSV test results to: %s", filename)
+		errExport := exportCsv(filename, info)
+		if errExport != nil {
+			log.Printf("handleConnectionClient: export CSV: %s: %v", filename, errExport)
+		}
+	}
+
+	if app.export != "" {
+		filename := fmt.Sprintf(app.export, c, conn.RemoteAddr())
+		log.Printf("exporting YAML test results to: %s", filename)
+		errExport := export(filename, info)
+		if errExport != nil {
+			log.Printf("handleConnectionClient: export YAML: %s: %v", filename, errExport)
+		}
+	}
+
+	if app.chart != "" {
+		filename := fmt.Sprintf(app.chart, c, conn.RemoteAddr())
+		log.Printf("rendering chart to: %s", filename)
+		errRender := chartRender(filename, &info.Input, &info.Output)
+		if errRender != nil {
+			log.Printf("handleConnectionClient: render PNG: %s: %v", filename, errRender)
+		}
+	}
+
+	plotascii(info, conn.RemoteAddr().String(), c)
 }

--- a/goben/csv.go
+++ b/goben/csv.go
@@ -22,25 +22,36 @@ func exportCsv(filename string, info *ExportInfo) error {
 
 	w := csv.NewWriter(out)
 
-	entry := []string{"DIRECTION", "TIME", "RATE"}
+	if info.completionTime == 0 {
+		entry := []string{"DIRECTION", "TIME", "RATE"}
 
-	if errHeader := w.Write(entry); errHeader != nil {
-		return errHeader
-	}
-
-	entry[Dir] = "input"
-	for i, x := range info.Input.XValues {
-		entry[Time] = x.String()
-		entry[Rate] = fmt.Sprintf("%v", info.Input.YValues[i])
-		if err := w.Write(entry); err != nil {
-			return err
+		if errHeader := w.Write(entry); errHeader != nil {
+			return errHeader
 		}
-	}
 
-	entry[Dir] = "output"
-	for i, x := range info.Output.XValues {
-		entry[Time] = x.String()
-		entry[Rate] = fmt.Sprintf("%v", info.Output.YValues[i])
+		entry[Dir] = "input"
+		for i, x := range info.Input.XValues {
+			entry[Time] = x.String()
+			entry[Rate] = fmt.Sprintf("%v", info.Input.YValues[i])
+			if err := w.Write(entry); err != nil {
+				return err
+			}
+		}
+
+		entry[Dir] = "output"
+		for i, x := range info.Output.XValues {
+			entry[Time] = x.String()
+			entry[Rate] = fmt.Sprintf("%v", info.Output.YValues[i])
+			if err := w.Write(entry); err != nil {
+				return err
+			}
+		}
+	} else {
+		entry := []string{"completion time"}
+		if errHeader := w.Write(entry); errHeader != nil {
+			return errHeader
+		}
+		entry[0] = fmt.Sprintf("%v", info.completionTime.Nanoseconds())
 		if err := w.Write(entry); err != nil {
 			return err
 		}

--- a/goben/main.go
+++ b/goben/main.go
@@ -80,7 +80,7 @@ func main() {
 	flag.StringVar(&app.chart, "chart", "", "output filename for rendering chart on client\n'%d' is parallel connection index to host\n'%s' is hostname:port\nexample: -chart chart-%d-%s.png")
 	flag.StringVar(&app.export, "export", "", "output filename for YAML exporting test results on client\n'%d' is parallel connection index to host\n'%s' is hostname:port\nexample: -export export-%d-%s.yaml")
 	flag.StringVar(&app.csv, "csv", "", "output filename for CSV exporting test results on client\n'%d' is parallel connection index to host\n'%s' is hostname:port\nexample: -csv export-%d-%s.csv")
-	flag.BoolVar(&app.ascii, "ascii", true, "plot ascii chart\nthis will automatically set to false when totalDuration is inf")
+	flag.BoolVar(&app.ascii, "ascii", false, "plot ascii chart\nthis will automatically set to false when totalDuration is inf")
 	flag.BoolVar(&app.silent, "silent", false, "Do not print any output")
 	flag.StringVar(&app.tlsKey, "key", "key.pem", "TLS key file")
 	flag.StringVar(&app.tlsCert, "cert", "cert.pem", "TLS cert file")

--- a/goben/main.go
+++ b/goben/main.go
@@ -36,7 +36,6 @@ type config struct {
 	tlsKey         string
 	tls            bool
 	debug		   bool
-	totalFlow	   uint64
 }
 
 func (h *hostList) String() string {
@@ -87,7 +86,7 @@ func main() {
 	flag.StringVar(&app.tlsCert, "cert", "cert.pem", "TLS cert file")
 	flag.BoolVar(&app.tls, "tls", true, "set to false to disable TLS")
 	flag.BoolVar(&app.debug, "debug", false, "if set to true, will print the process indicator messages in the console to help debugging")
-	flag.Uint64Var(&app.totalFlow, "totalFlow", 0, "test bandwidth/latency by given total amount of data transmitted over each connection\ndata unit defaults to kB, totalDuration flag will be disabled")
+	flag.Uint64Var(&app.opt.TotalFlow, "totalFlow", 0, "test bandwidth/latency by given total amount of data transmitted over each connection\ndata unit defaults to kB, totalDuration flag will be disabled")
 
 	flag.Parse()
 	if (app.silent) {

--- a/goben/main.go
+++ b/goben/main.go
@@ -36,6 +36,7 @@ type config struct {
 	tlsKey         string
 	tls            bool
 	debug		   bool
+	totalFlow	   uint64
 }
 
 func (h *hostList) String() string {
@@ -86,6 +87,7 @@ func main() {
 	flag.StringVar(&app.tlsCert, "cert", "cert.pem", "TLS cert file")
 	flag.BoolVar(&app.tls, "tls", true, "set to false to disable TLS")
 	flag.BoolVar(&app.debug, "debug", false, "if set to true, will print the process indicator messages in the console to help debugging")
+	flag.Uint64Var(&app.totalFlow, "totalFlow", 0, "test bandwidth/latency by given total amount of data transmitted over each connection\ndata unit defaults to kB, totalDuration flag will be disabled")
 
 	flag.Parse()
 	if (app.silent) {

--- a/goben/msg.go
+++ b/goben/msg.go
@@ -17,6 +17,7 @@ type options struct {
 	PassiveServer  bool              // suppress server send
 	MaxSpeed       float64           // mbps
 	Table          map[string]string // send optional information client->server
+	TotalFlow	   uint64			 // total amount of data transmitted over each connection
 }
 
 type ack struct {

--- a/goben/server.go
+++ b/goben/server.go
@@ -131,7 +131,7 @@ func handleTCP(app *config, wg *sync.WaitGroup, listener net.Listener, isTLS boo
 			log.Printf("handle: accept: %v", errAccept)
 			break
 		}
-		go handleConnection(conn, id, 0, isTLS)
+		go handleConnection(app, conn, id, 0, isTLS)
 		id++
 	}
 }
@@ -209,7 +209,7 @@ func handleUDP(app *config, wg *sync.WaitGroup, conn *net.UDPConn) {
 	}
 }
 
-func handleConnection(conn net.Conn, c, connections int, isTLS bool) {
+func handleConnection(app *config, conn net.Conn, c, connections int, isTLS bool) {
 	defer conn.Close()
 
 	log.Printf("handleConnection: incoming: %s %v", protoLabel(isTLS), conn.RemoteAddr())
@@ -230,23 +230,32 @@ func handleConnection(conn net.Conn, c, connections int, isTLS bool) {
 		return
 	}
 
-	go serverReader(conn, opt, c, connections, isTLS)
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go serverReader(conn, opt, c, connections, isTLS, &wg, app.totalFlow)
 
 	if !opt.PassiveServer {
 		go serverWriter(conn, opt, c, connections, isTLS)
 	}
 
-	tickerPeriod := time.NewTimer(opt.TotalDuration)
+	if app.totalFlow == 0 {
+		tickerPeriod := time.NewTimer(opt.TotalDuration)
 
-	<-tickerPeriod.C
-	log.Printf("handleConnection: %v timer", opt.TotalDuration)
+		<-tickerPeriod.C
+		log.Printf("handleConnection: %v timer", opt.TotalDuration)
 
-	tickerPeriod.Stop()
+		tickerPeriod.Stop()
+	} else {
+		wg.Wait()
+	}
 
 	log.Printf("handleConnection: closing: %v", conn.RemoteAddr())
 }
 
-func serverReader(conn net.Conn, opt options, c, connections int, isTLS bool) {
+func serverReader(conn net.Conn, opt options, c, connections int, isTLS bool, wg *sync.WaitGroup, totalFlow uint64) {
+
+	defer wg.Done()
 
 	log.Printf("serverReader: starting: %s %v", protoLabel(isTLS), conn.RemoteAddr())
 
@@ -254,7 +263,7 @@ func serverReader(conn net.Conn, opt options, c, connections int, isTLS bool) {
 
 	buf := make([]byte, opt.ReadSize)
 
-	workLoop(connIndex, "serverReader", "rcv/s", conn.Read, buf, opt.ReportInterval, 0, nil)
+	workLoop(connIndex, "serverReader", "rcv/s", conn.Read, buf, opt.ReportInterval, 0, nil, nil, totalFlow)
 
 	log.Printf("serverReader: exiting: %v", conn.RemoteAddr())
 }
@@ -274,7 +283,7 @@ func serverWriter(conn net.Conn, opt options, c, connections int, isTLS bool) {
 
 	buf := randBuf(opt.WriteSize)
 
-	workLoop(connIndex, "serverWriter", "snd/s", conn.Write, buf, opt.ReportInterval, opt.MaxSpeed, nil)
+	workLoop(connIndex, "serverWriter", "snd/s", conn.Write, buf, opt.ReportInterval, opt.MaxSpeed, nil, nil, 0)
 
 	log.Printf("serverWriter: exiting: %v", conn.RemoteAddr())
 }
@@ -296,7 +305,7 @@ func serverWriterTo(conn *net.UDPConn, opt options, dst net.Addr, acc *account, 
 
 	buf := randBuf(opt.WriteSize)
 
-	workLoop(connIndex, "serverWriterTo", "snd/s", udpWriteTo, buf, opt.ReportInterval, opt.MaxSpeed, nil)
+	workLoop(connIndex, "serverWriterTo", "snd/s", udpWriteTo, buf, opt.ReportInterval, opt.MaxSpeed, nil, nil, 0)
 
 	log.Printf("serverWriterTo: exiting: %v", dst)
 }

--- a/goben/server.go
+++ b/goben/server.go
@@ -131,7 +131,7 @@ func handleTCP(app *config, wg *sync.WaitGroup, listener net.Listener, isTLS boo
 			log.Printf("handle: accept: %v", errAccept)
 			break
 		}
-		go handleConnection(app, conn, id, 0, isTLS)
+		go handleConnection(conn, id, 0, isTLS)
 		id++
 	}
 }
@@ -209,7 +209,7 @@ func handleUDP(app *config, wg *sync.WaitGroup, conn *net.UDPConn) {
 	}
 }
 
-func handleConnection(app *config, conn net.Conn, c, connections int, isTLS bool) {
+func handleConnection(conn net.Conn, c, connections int, isTLS bool) {
 	defer conn.Close()
 
 	log.Printf("handleConnection: incoming: %s %v", protoLabel(isTLS), conn.RemoteAddr())
@@ -233,13 +233,13 @@ func handleConnection(app *config, conn net.Conn, c, connections int, isTLS bool
 	var wg sync.WaitGroup
 
 	wg.Add(1)
-	go serverReader(conn, opt, c, connections, isTLS, &wg, app.totalFlow)
+	go serverReader(conn, opt, c, connections, isTLS, &wg, opt.TotalFlow)
 
 	if !opt.PassiveServer {
 		go serverWriter(conn, opt, c, connections, isTLS)
 	}
 
-	if app.totalFlow == 0 {
+	if opt.TotalFlow == 0 {
 		tickerPeriod := time.NewTimer(opt.TotalDuration)
 
 		<-tickerPeriod.C


### PR DESCRIPTION
Added a new flag "-totalFlow" to measure the total completion
time takes to send a fixed amount of data over a connection.
The value for "-totalFlow" is an uint64. When the "-totalFlow"
is on, the timeout feature ("-totalDuration") is disabled. The
program will automatically exit when all the data are sent.
To enable the "-totalFlow", server side needs to provide two
extra flags "-totalFlow" and "-passiveServer". The values of
"-totalFlow" for both client side and server side should be
the same.

 Changes to be committed:
	modified:   client.go
	modified:   csv.go
	modified:   main.go
	modified:   server.go